### PR TITLE
update hack store to have the official testing website

### DIFF
--- a/programs.json
+++ b/programs.json
@@ -142,7 +142,7 @@
         {
             "name": "Hack Store",
             "description": "Use a free alternative app store and get a Google Developer account.",
-            "website": null,
+            "website": "https://www.hackstore.dev/",
             "slack": "https://slack.com/archives/C07BGFG6CDQ",
             "slackChannel": "#hack-store",
             "status": "upcoming"


### PR DESCRIPTION
This pull request includes a small change to the `programs.json` file. The change updates the `website` field for the "Hack Store" entry to include the correct URL.

* [`programs.json`](diffhunk://#diff-144e30be56d2ef00081b5b43d6af3ae5a6efdc6654cc6f63ef71ff461bc8f13aL145-R145): Updated the `website` field for the "Hack Store" entry to "https://www.hackstore.dev/"