### PR TITLE
Add Arcade 2024 to the completed YSWS programs list

### DIFF
--- a/programs.json
+++ b/programs.json
@@ -217,6 +217,14 @@
     ],
     "completed": [
         {
+            "name": "Arcade",
+            "description": "The summer is yours for the making",
+            "website": "https://hackclub.com/arcade",
+            "slack": "https://hackclub.slack.com/archives/C06SBHMQU8G",
+            "slackChannel": "#hack-hour"
+            "status": "completed"
+        },
+        {
             "name": "Blot",
             "description": "Write code, make art, and get a drawing machine.",
             "website": "https://blot.hackclub.com/",


### PR DESCRIPTION
Might backfill past YSWS programs in the future. Also note that `#hack-hour` is the initial name before the 2024 summer event + [beta testing period](https://hackclub.com/arcade/power-hour/).